### PR TITLE
Add customization for delivery frequency

### DIFF
--- a/server.py
+++ b/server.py
@@ -22,8 +22,28 @@ auto;max-width:650px;line-height:1.6;font-size:18px;color:#444;padding:0
 UNSUB_GET_TEMPLATE = tornado.template.Template("""
 <h1>TorWeather Unsubscribe</h1>
 <p>Sorry to see you go. :(</p>
+<p>(To change the frequency of emails instead, you can go
+<a href="/subscribe?hmac={{hmac}}&fingerprint={{fingerprint}}">here</a>.)</p>
 <form action="/unsubscribe" method="POST">
 <input type="submit" value="Unsubscribe" />
+<input type="hidden" name="hmac" value="{{hmac}}" />
+<input type="hidden" name="fingerprint" value="{{fingerprint}}" />
+</form>
+<p>Go <a href="/">home</a>?</p>
+""")
+
+UNSUB_GET_TEMPLATE = tornado.template.Template("""
+<h1>TorWeather Email Frequency</h1>
+<p>Update your notification sensitivity.</p>
+<form action="/subscribe" method="POST">
+<select name="frequency">
+    <option value="10800">3 Hours</option>
+    <option value="43200">12 Hours</option>
+    <option value="86400">1 Day</option>
+    <option value="172800">2 Days (default)</option>
+    <option value="604800">1 Week</option>
+</select>
+<input type="submit" value="Update" />
 <input type="hidden" name="hmac" value="{{hmac}}" />
 <input type="hidden" name="fingerprint" value="{{fingerprint}}" />
 </form>
@@ -58,6 +78,48 @@ class UnsubscribeHandler(tornado.web.RequestHandler):
 
         self.write(wrap_render("Successfully unsubscribed."))
 
+class SubscribeHandler(tornado.web.RequestHandler):
+    def get(self):
+        fingerprint = self.get_argument('fingerprint')
+        hmac = self.get_argument('hmac')
+
+        if not verify(hmac, fingerprint):
+            self.set_status(403)
+            self.write('hmac invalid :(')
+            return
+
+        self.write(wrap_render(SUB_GET_TEMPLATE, fingerprint=fingerprint, hmac=hmac))
+
+    def post(self):
+        fingerprint = self.get_argument('fingerprint')
+        frequency = self.get_argument('frequency')
+        parsedfreq = 60 * 60 * 24 * 2
+        hmac = self.get_argument('hmac')
+
+        if not verify(hmac, fingerprint):
+            self.set_status(403)
+            self.write('hmac invalid :(')
+            return
+
+        try:
+            parsedfreq = int(frequency)
+            if parsedfreq < 1:
+                self.set_status(403)
+                self.write('frequency invalid :(')
+                return
+        except ValueError:
+            self.set_status(403)
+            self.write('frequency invalid :(')
+            return
+
+        conn = sqlite3.connect('TorWeather.db')
+        with conn:
+            conn.execute("INSERT OR REPLACE INTO subscribe (fingerprint, frequency) VALUES (:fingerprint, :frequency);",
+                         {'fingerprint': fingerprint, 'frequency': parsedfreq})
+
+        self.write(wrap_render("Successfully unsubscribed."))
+
+
 class RootHandler(tornado.web.RequestHandler):
     def get(self):
         self.redirect('https://github.com/thingless/torweather')
@@ -65,6 +127,7 @@ class RootHandler(tornado.web.RequestHandler):
 if __name__ == "__main__":
     app = tornado.web.Application([
         (r"/unsubscribe", UnsubscribeHandler),
+        (r"/subscribe", SubscribeHandler),
         (r"/", RootHandler),
     ])
     port = os.environ.get('PORT', 8080)

--- a/server.py
+++ b/server.py
@@ -32,7 +32,7 @@ UNSUB_GET_TEMPLATE = tornado.template.Template("""
 <p>Go <a href="/">home</a>?</p>
 """)
 
-UNSUB_GET_TEMPLATE = tornado.template.Template("""
+SUB_GET_TEMPLATE = tornado.template.Template("""
 <h1>TorWeather Email Frequency</h1>
 <p>Update your notification sensitivity.</p>
 <form action="/subscribe" method="POST">


### PR DESCRIPTION
Fix #1 

This adds a `/subscribe` handler which updates a `subscribe` database table that contains a numeric (in seconds) frequency override that can be set per node fingerprint.
The handler uses the same authentication as the unsubscribe handler, and is exposed via a link from the unsubscribe page.