### PR TITLE
Fixed broken torrc reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tor Weather
 
-Tor Weather will inform the user listed in [torrc's](https://www.torproject.org/docs/tor-doc-relay.html.en) `ContactInfo` field via email in the event of downtime lasting longer than 48 hours.
+Tor Weather will inform the user listed in [torrc's](https://community.torproject.org/relay/setup/guard/debian-ubuntu) `ContactInfo` field via email in the event of downtime lasting longer than 48 hours.
 
 ## Tor Weather's History
 


### PR DESCRIPTION
Updated [broken torrc reference](https://web.archive.org/web/20170128170351/https://www.torproject.org/docs/tor-doc-relay.html.en) with similar reference